### PR TITLE
Add Long Click Listener to Remove Firmware in FirmwareImportPreference

### DIFF
--- a/app/src/main/java/emu/skyline/preference/FirmwareImportPreference.kt
+++ b/app/src/main/java/emu/skyline/preference/FirmwareImportPreference.kt
@@ -88,14 +88,11 @@ class FirmwareImportPreference @JvmOverloads constructor(context: Context, attrs
 
             getPersistedString(defaultString)
         }
-        
-        setOnPreferenceLongClickListener {
-            showRemoveFirmwareConfirmationDialog()
-            true
-        }
     }
 
     override fun onClick() = documentPicker.launch(arrayOf("application/zip"))
+
+    override fun onLongClick() = showRemoveFirmwareConfirmationDialog()
 
     private fun showRemoveFirmwareConfirmationDialog() {
         MaterialAlertDialogBuilder(context)

--- a/app/src/main/java/emu/skyline/preference/FirmwareImportPreference.kt
+++ b/app/src/main/java/emu/skyline/preference/FirmwareImportPreference.kt
@@ -12,6 +12,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.preference.Preference
 import androidx.preference.Preference.SummaryProvider
 import com.google.android.material.snackbar.Snackbar
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import emu.skyline.R
 import emu.skyline.fragments.IndeterminateProgressDialogFragment
 import emu.skyline.getPublicFilesDir
@@ -89,12 +90,23 @@ class FirmwareImportPreference @JvmOverloads constructor(context: Context, attrs
         }
         
         setOnPreferenceLongClickListener {
-            removeFirmware()
+            showRemoveFirmwareConfirmationDialog()
             true
         }
     }
 
     override fun onClick() = documentPicker.launch(arrayOf("application/zip"))
+
+    private fun showRemoveFirmwareConfirmationDialog() {
+        MaterialAlertDialogBuilder(context)
+            .setTitle(R.string.remove_firmware_title)
+            .setMessage(R.string.remove_firmware_confirmation)
+            .setPositiveButton(R.string.remove) { _, _ ->
+                removeFirmware()
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
 
     private fun removeFirmware() {
         if (firmwarePath.exists()) {

--- a/app/src/main/java/emu/skyline/preference/FirmwareImportPreference.kt
+++ b/app/src/main/java/emu/skyline/preference/FirmwareImportPreference.kt
@@ -11,6 +11,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.preference.Preference
 import androidx.preference.Preference.SummaryProvider
+import androidx.preference.PreferenceViewHolder
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import emu.skyline.R
@@ -95,7 +96,7 @@ class FirmwareImportPreference @JvmOverloads constructor(context: Context, attrs
     override fun onBindViewHolder(holder: PreferenceViewHolder) {
         super.onBindViewHolder(holder)
         holder.itemView.setOnLongClickListener {
-            showRemoveFirmwareDialog()
+            showRemoveFirmwareConfirmationDialog()
             true
         }
     }

--- a/app/src/main/java/emu/skyline/preference/FirmwareImportPreference.kt
+++ b/app/src/main/java/emu/skyline/preference/FirmwareImportPreference.kt
@@ -92,7 +92,13 @@ class FirmwareImportPreference @JvmOverloads constructor(context: Context, attrs
 
     override fun onClick() = documentPicker.launch(arrayOf("application/zip"))
 
-    override fun onLongClick() = showRemoveFirmwareConfirmationDialog()
+    override fun onBindViewHolder(holder: PreferenceViewHolder) {
+        super.onBindViewHolder(holder)
+        holder.itemView.setOnLongClickListener {
+            showRemoveFirmwareDialog()
+            true
+        }
+    }
 
     private fun showRemoveFirmwareConfirmationDialog() {
         MaterialAlertDialogBuilder(context)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,8 @@
     <string name="import_firmware_invalid_contents">The supplied firmware package does not contain a valid firmware</string>
     <string name="firmware_keys_needed">Valid keys are required for firmware installation</string>
     <string name="firmware_not_installed">No firmware installed</string>
+    <string name="firmware_removed">Firmware removed successfully</string>
+    <string name="firmware_not_found">Firmware not found</string>
     <!-- Settings - Appearance -->
     <string name="appearance">Appearance</string>
     <string name="theme">Theme</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,6 +56,9 @@
     <string name="firmware_not_installed">No firmware installed</string>
     <string name="firmware_removed">Firmware removed successfully</string>
     <string name="firmware_not_found">Firmware not found</string>
+    <string name="remove_firmware_title">Remove Firmware</string>
+    <string name="remove_firmware_confirmation">Are you sure you want to remove the firmware?</string>
+    <string name="remove">Remove</string>
     <!-- Settings - Appearance -->
     <string name="appearance">Appearance</string>
     <string name="theme">Theme</string>


### PR DESCRIPTION
### Summary
This pull request adds functionality to the `FirmwareImportPreference` class to handle long-click events. When a user long-clicks the preference, a dialog is displayed asking for confirmation to remove the installed firmware. If confirmed, the firmware is deleted, and a Snackbar notification is shown.

### Changes
- Override `onBindViewHolder` to set a long-click listener on the preference view.
- Implement `showRemoveFirmwareDialog` to display a confirmation dialog for removing the firmware.
- Add `removeFirmware` method to delete the firmware and show a Snackbar notification.
- Ensure necessary imports for `PreferenceViewHolder` and `MaterialAlertDialogBuilder`.

### Testing
- Verified that long-clicking the firmware import preference shows the confirmation dialog.
- Tested the removal of firmware and confirmed that it updates the UI and shows a Snackbar notification.


