### PR TITLE
Integrate GPU memory mapping using adrenotools_mem_gpu_allocate and a…

### DIFF
--- a/app/src/main/cpp/skyline/gpu.cpp
+++ b/app/src/main/cpp/skyline/gpu.cpp
@@ -343,7 +343,8 @@ namespace skyline::gpu {
 
     static PFN_vkGetInstanceProcAddr LoadVulkanDriver(const DeviceState &state, adrenotools_gpu_mapping *mapping) {
         void *libvulkanHandle{};
-        void *userMappingHandle = nullptr; // New void* pointer for user mapping handle
+        void *userMappingHandle = nullptr;
+        uint64_t gpuMemSize = 0;
 
         // If the user has selected a custom driver, try to load it
         if (!(*state.settings->gpuDriver).empty()) {
@@ -355,15 +356,24 @@ namespace skyline::gpu {
                 (state.os->privateAppFilesPath + "gpu_drivers/" + *state.settings->gpuDriver + "/").c_str(),
                 (*state.settings->gpuDriverLibraryName).c_str(),
                 (state.os->publicAppFilesPath + "gpu/vk_file_redirect/").c_str(),
-                reinterpret_cast<void**>(&userMappingHandle) // Use reinterpret_cast to pass as void**
+                reinterpret_cast<void**>(&userMappingHandle)
             );
 
-            // Cast the userMappingHandle back to adrenotools_gpu_mapping*
             if (libvulkanHandle) {
                 mapping = reinterpret_cast<adrenotools_gpu_mapping*>(userMappingHandle);
-            }
 
-            if (!libvulkanHandle) {
+                // GPU memory allocation
+                if (!adrenotools_mem_gpu_allocate(userMappingHandle, &gpuMemSize)) {
+                    LOGW("Failed to allocate GPU memory.");
+                    return nullptr;
+                }
+
+                // CPU-side memory mapping
+                if (!adrenotools_mem_cpu_map(userMappingHandle, mapping->host_ptr, gpuMemSize)) {
+                    LOGW("Failed to map GPU memory to CPU.");
+                    return nullptr;
+                }
+            } else {
                 char *error = dlerror();
                 LOGW("Failed to load custom Vulkan driver {}/{}: {}", *state.settings->gpuDriver, *state.settings->gpuDriverLibraryName, error ? error : "");
             }
@@ -378,15 +388,24 @@ namespace skyline::gpu {
                 nullptr,
                 nullptr,
                 (state.os->publicAppFilesPath + "gpu/vk_file_redirect/").c_str(),
-                reinterpret_cast<void**>(&userMappingHandle) // Use reinterpret_cast for user mapping handle
+                reinterpret_cast<void**>(&userMappingHandle)
             );
 
-            // Cast the userMappingHandle back to adrenotools_gpu_mapping*
             if (libvulkanHandle) {
                 mapping = reinterpret_cast<adrenotools_gpu_mapping*>(userMappingHandle);
-            }
 
-            if (!libvulkanHandle) {
+                // GPU memory allocation
+                if (!adrenotools_mem_gpu_allocate(userMappingHandle, &gpuMemSize)) {
+                    LOGW("Failed to allocate GPU memory.");
+                    return nullptr;
+                }
+
+                // CPU-side memory mapping
+                if (!adrenotools_mem_cpu_map(userMappingHandle, mapping->host_ptr, gpuMemSize)) {
+                    LOGW("Failed to map GPU memory to CPU.");
+                    return nullptr;
+                }
+            } else {
                 char *error = dlerror();
                 LOGW("Failed to load builtin Vulkan driver: {}", error ? error : "");
             }
@@ -396,6 +415,7 @@ namespace skyline::gpu {
         }
         return reinterpret_cast<PFN_vkGetInstanceProcAddr>(dlsym(libvulkanHandle, "vkGetInstanceProcAddr"));
     }
+
 
 
     GPU::GPU(const DeviceState &state)


### PR DESCRIPTION
- Added GPU memory allocation using adrenotools_mem_gpu_allocate in Vulkan driver loading process.
- Mapped the allocated GPU memory to the CPU using adrenotools_mem_cpu_map.
- Ensured correct memory allocation and mapping steps are executed after loading the Vulkan driver.
- Updated error handling for memory allocation and mapping failures.
