### PR TITLE
IAudioRendererManager: Fix incorrect ``transferMemorySize``

### DIFF
--- a/app/src/main/cpp/skyline/services/audio/IAudioRendererManager.cpp
+++ b/app/src/main/cpp/skyline/services/audio/IAudioRendererManager.cpp
@@ -39,7 +39,7 @@ namespace skyline::service::audio {
 
             manager.RegisterService(renderer, session, response);
         } catch (const std::bad_alloc &e) {
-            LOGE("Memory allocation failed: %s", e.what());
+            LOGE("Memory allocation failed: {}", e.what());
             return Result{Service::Audio::ResultOperationFailed};
         }
         return {};

--- a/app/src/main/cpp/skyline/services/audio/IAudioRendererManager.cpp
+++ b/app/src/main/cpp/skyline/services/audio/IAudioRendererManager.cpp
@@ -17,6 +17,8 @@ namespace skyline::service::audio {
     IAudioRendererManager::IAudioRendererManager(const DeviceState &state, ServiceManager &manager)
         : BaseService(state, manager) {}
 
+    u64 GetTotalRAM();
+
     Result IAudioRendererManager::OpenAudioRenderer(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         const auto &params{request.Pop<AudioCore::AudioRendererParameterInternal>()};
         u64 transferMemorySize{request.Pop<u64>()};

--- a/app/src/main/cpp/skyline/services/audio/IAudioRendererManager.cpp
+++ b/app/src/main/cpp/skyline/services/audio/IAudioRendererManager.cpp
@@ -27,12 +27,18 @@ namespace skyline::service::audio {
             return Result{Service::Audio::ResultOutOfSessions};
         }
 
-        manager.RegisterService(std::make_shared<IAudioRenderer>(state, manager,
-                                                                 *state.audio->audioRendererManager,
-                                                                 params,
-                                                                 transferMemorySize, processHandle, appletResourceUserId, sessionId),
-                                session, response);
+        try {
+            auto renderer = std::make_shared<IAudioRenderer>(
+                state, manager,
+                *state.audio->audioRendererManager,
+                params, transferMemorySize, processHandle, appletResourceUserId,
+                state.audio->audioRendererManager->GetSessionId());
 
+            manager.RegisterService(renderer, session, response);
+        } catch (const std::bad_alloc &e) {
+            LOGE("Memory allocation failed: %s", e.what());
+            return Result{Service::Audio::ResultOperationFailed};
+        }
         return {};
     }
 

--- a/app/src/main/cpp/skyline/services/audio/IAudioRendererManager.cpp
+++ b/app/src/main/cpp/skyline/services/audio/IAudioRendererManager.cpp
@@ -22,7 +22,7 @@ namespace skyline::service::audio {
         auto processHandle{request.copyHandles.at(1)};
 
         // Log the transferMemorySize
-        LOGI("TransferMemorySize: %llu", transferMemorySize);
+        LOGI("TransferMemorySize: {}", transferMemorySize);
 
         i32 sessionId{state.audio->audioRendererManager->GetSessionId()};
         if (sessionId == -1) {

--- a/app/src/main/cpp/skyline/services/audio/IAudioRendererManager.cpp
+++ b/app/src/main/cpp/skyline/services/audio/IAudioRendererManager.cpp
@@ -21,6 +21,9 @@ namespace skyline::service::audio {
         auto transferMemoryHandle{request.copyHandles.at(0)};
         auto processHandle{request.copyHandles.at(1)};
 
+        // Log the transferMemorySize
+        LOGI("TransferMemorySize: %llu", transferMemorySize);
+
         i32 sessionId{state.audio->audioRendererManager->GetSessionId()};
         if (sessionId == -1) {
             LOGW("Out of audio renderer sessions!");


### PR DESCRIPTION
Fixes a crash caused by an incorrect transferMemorySize in AudioRendererManager. This issue was affecting games such as Super Mario World 3D + Bowser's Fury and other titles.